### PR TITLE
Fix: 이메일 중복체크 수정

### DIFF
--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -43,13 +43,20 @@ const Register = () => {
         emailMessage: "사용 불가능한 이메일입니다.",
       }));
       setIsValid({ ...isValid, checkedPassword: false });
-    } else {
+    } else if (emailResult?.data.isExist == false) {
       // 이메일 사용 가능
       setValidMessage((prev) => ({
         ...prev,
         emailMessage: "사용 가능한 이메일입니다.",
       }));
       setIsValid({ ...isValid, checkedPassword: true });
+    } else {
+      // 기타 상황
+      setValidMessage((prev) => ({
+        ...prev,
+        emailMessage: "잠시 후 다시 시도해주세요.",
+      }));
+      setIsValid({ ...isValid, checkedPassword: false });
     }
   };
 


### PR DESCRIPTION
#26 이메일 중복체크 api 연결 안되는 상황이면 '사용 가능한 이메일입니다'라고 뜨는 것 고침